### PR TITLE
Changed Crowdin link from ru to www

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Any contributions you make are **greatly appreciated**.
 5. Open a Pull Request
 
 ## Localisation
-[![Crowdin](https://is.gd/TfsUVl)](https://ru.crowdin.com/project/blockify)
+[![Crowdin](https://is.gd/TfsUVl)](https://www.crowdin.com/project/blockify)


### PR DESCRIPTION
Basically the link to Crowdin page uses ru. instead of www. I think it is better to have it with www as it's more common and I think Corwdin will put you to your language that way instead of forcing Russian.